### PR TITLE
CI: fix kubernetes repository

### DIFF
--- a/ci/ci.Dockerfile
+++ b/ci/ci.Dockerfile
@@ -1,5 +1,5 @@
 # This Docerfile is the environment where the test will be run in.
-FROM registry.ci.openshift.org/openshift/release:golang-1.20
+FROM registry.ci.openshift.org/openshift/release:golang-1.21
 
 # Add kubernetes repository
 ADD ci/kubernetes.repo /etc/yum.repos.d/

--- a/ci/kubernetes.repo
+++ b/ci/kubernetes.repo
@@ -1,7 +1,7 @@
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm


### PR DESCRIPTION
The packages.cloud.google.com has been deprecated for a while.
See https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>