### PR TITLE
Added support for the proxy_* params that are supported in clustertask task-maven

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,14 @@ E2E_TESTS ?= ./test/e2e/*.bats
 
 E2E_PVC ?= test/e2e/resources/pvc-maven.yaml
 E2E_SECRET ?= test/e2e/resources/secret-maven.yaml
+E2E_PROXY_SECRET ?= test/e2e/resources/secret-proxy-maven.yaml                #
+E2E_CONFIGMAP ?= test/e2e/resources/configmap-proxy-maven.yaml                #
 E2E_MAVEN_PARAMS_REVISION ?= master
 E2E_MAVEN_PARAMS_URL ?= https://github.com/Aneesh-M-Bhat/shopping-cart-test-java
 E2E_TEST_DIR ?= ./test/e2e
 E2E_MAVEN_PARAMS_SERVER_SECRET ?= secret-maven
+E2E_MAVEN_PARAMS_PROXY_SECRET ?= secret-proxy-maven                               #
+E2E_MAVEN_PARAMS_PROXY_CONFIGMAP ?= config-proxy-maven                              #
 
 # generic arguments employed on most of the targets
 ARGS ?=
@@ -107,6 +111,8 @@ bats: install
 prepare-e2e:
 	kubectl apply -f ${E2E_PVC}
 	kubectl apply -f ${E2E_SECRET}
+	kubectl apply -f ${E2E_PROXY_SECRET}
+	kubectl apply -f ${E2E_CONFIGMAP}
 
 # run end-to-end tests against the current kuberentes context, it will required a cluster with tekton
 # pipelines and other requirements installed, before start testing the target invokes the

--- a/templates/task-maven.yaml
+++ b/templates/task-maven.yaml
@@ -17,9 +17,15 @@ spec:
     - name: source
       optional: false
       description: The workspace consisting of maven project.
-    - name: sever_secret
+    - name: server_secret
       optional: true
       description: The workspace containing server secrets (user and password file)
+    - name: proxy_secret
+      optional: true
+      description: The workspace containing proxy server access credentials.
+    - name: proxy_configmap
+      optional: true
+      description: The workspace containing some proxy values (proxy_port,proxy_host,proxy_non_proxy_hosts)
 
   params:
     - name: GOALS
@@ -47,6 +53,10 @@ spec:
       "workspaces.source.bound"
       "workspaces.server_secret.path"
       "workspaces.server_secret.bound"
+      "workspaces.proxy_secret.path"
+      "workspaces.proxy_secret.bound"
+      "workspaces.proxy_configmap.path"
+      "workspaces.proxy_configmap.bound"
 }}
 {{- include "environment" ( list $variables ) | nindent 6 }}
 

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -9,12 +9,16 @@ source ./test/helper/helper.sh
     [ -n "${E2E_MAVEN_PARAMS_URL}" ]
     [ -n "${E2E_MAVEN_PARAMS_REVISION}" ]
     [ -n "${E2E_MAVEN_PARAMS_SERVER_SECRET}" ]
+    [ -n "${E2E_MAVEN_PARAMS_PROXY_SECRET}" ]
+    [ -n "${E2E_MAVEN_PARAMS_PROXY_CONFIGMAP}" ]
     
     run tkn pipeline start task-maven \
         --param="URL=${E2E_MAVEN_PARAMS_URL}" \
         --param="REVISION=${E2E_MAVEN_PARAMS_REVISION}" \
         --param="VERBOSE=true" \
         --workspace="name=server_secret,secret=${E2E_MAVEN_PARAMS_SERVER_SECRET}" \
+        --workspace="name=proxy_secret,secret=${E2E_MAVEN_PARAMS_PROXY_SECRET}" \
+        --workspace="name=proxy_configmap,secret=${E2E_MAVEN_PARAMS_PROXY_CONFIGMAP}" \
         --workspace="name=source,claimName=task-maven,subPath=source" \
         --filename=test/e2e/resources/pipeline-maven.yaml \
         --showlog

--- a/test/e2e/resources/configmap-proxy-maven.yaml
+++ b/test/e2e/resources/configmap-proxy-maven.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-proxy-maven
+data:
+  proxy_host: "some-proxy-host"
+  proxy_port: "8080"
+  proxy_protocol: "http"
+  proxy_non_proxy_hosts: "example.com"

--- a/test/e2e/resources/pipeline-maven.yaml
+++ b/test/e2e/resources/pipeline-maven.yaml
@@ -11,6 +11,11 @@ spec:
       optional: false
     - name: server_secret
       optional: true
+    - name: proxy_secret
+      optional: true
+    - name: proxy_configmap
+      optional: true
+
 
   params:
     - name: URL

--- a/test/e2e/resources/secret-proxy-maven.yaml
+++ b/test/e2e/resources/secret-proxy-maven.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-proxy-maven
+type: Opaque
+stringData:
+  username: some-username
+  password: some-password


### PR DESCRIPTION
With reference to issue #2 I have enabled support for all the proxy_* params present in task-maven clustertask. I have enabled it using workspaces and configmaps. 
Signed off by :- @Senjuti256 <sde@redhat.com>