### PR TITLE
Update CI dockerfile to fix CentOS changes

### DIFF
--- a/ci/ci.Dockerfile
+++ b/ci/ci.Dockerfile
@@ -4,6 +4,11 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.21
 # Add kubernetes repository
 ADD ci/kubernetes.repo /etc/yum.repos.d/
 
+# Change baseurl for CentOS EOL workaround
+# https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/ 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y kubectl httpd-tools jq make git which
 RUN  rpm -Uvh https://github.com/tektoncd/cli/releases/download/v0.33.0/tektoncd-cli-0.33.0_Linux-64bit.rpm
 

--- a/hack/install-osp.sh
+++ b/hack/install-osp.sh
@@ -92,7 +92,7 @@ esac
 
 # wait until tekton pipelines operator is created
 echo "Waiting for OpenShift Pipelines Operator to be created..."
-timeout 2m bash <<- EOF
+timeout 3m bash <<- EOF
   until oc get deployment openshift-pipelines-operator -n openshift-operators; do
     sleep 5
   done


### PR DESCRIPTION
Since CentOS is deprecated our CI Dockerfile is failing to build the image.
https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
The following changes are the workarounds to change the baseurl