### PR TITLE
Add JAVA_VERSION parameter to Maven Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ The `server_secret` is optional. It should contain two *files* : `username` and 
 |:-------------------|:---------|:-----------|:-----------------------------------------------------------------------------------|
 | `GOALS`            | `string` | `package`  | The `maven` goal(s) to run                                                         |
 | `MAVEN_MIRROR_URL` | `string` | "" (empty) | The maven repository mirror URL to use                                             |
+| `JAVA_VERSION`     | `string` | `11`       | Java version to use for the Maven build (e.g. `8`, `11`, `17`, `21`)               |
 | `SUBDIRECTORY`     | `string` | `.`        | The subdirectory of the `source` workspace on which we want to execute maven goals |
 

--- a/templates/task-maven.yaml
+++ b/templates/task-maven.yaml
@@ -39,6 +39,12 @@ spec:
       description: The Maven repository mirror url
       type: string
       default: ""
+    - name: JAVA_VERSION
+      description: >-
+        Java version to use for the Maven build.
+        Supported values: 8, 11, 17, 21.
+      type: string
+      default: "11"
     - name: SUBDIRECTORY
       type: string
       description: >-
@@ -85,7 +91,7 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-      image: {{ .Values.images.maven }}
+      image: {{ .Values.images.maven }}$(params.JAVA_VERSION):latest
       workingDir: $(workspaces.source.path)/$(params.SUBDIRECTORY)
       command: ["/usr/bin/mvn"]
       args:

--- a/test/e2e/resources/pipeline-maven.yaml
+++ b/test/e2e/resources/pipeline-maven.yaml
@@ -53,8 +53,6 @@ spec:
       taskRef:
         name: maven
       params:
-        - name: SERVER_SECRET
-          value: "$(params.SERVER_SECRET)"
         - name: GOALS
           value:
             - "validate"
@@ -65,3 +63,9 @@ spec:
       workspaces:
         - name: source
           workspace: source
+        - name: server_secret
+          workspace: server_secret
+        - name: proxy_secret
+          workspace: proxy_secret
+        - name: proxy_configmap
+          workspace: proxy_configmap

--- a/test/e2e/resources/taskrun-maven-java11.yaml
+++ b/test/e2e/resources/taskrun-maven-java11.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: maven-java11-
+  labels:
+    test: java-version
+spec:
+  taskRef:
+    name: maven
+  params:
+    - name: GOALS
+      value:
+        - "--version"
+  workspaces:
+    - name: source
+      emptyDir: {}

--- a/test/e2e/resources/taskrun-maven-java17.yaml
+++ b/test/e2e/resources/taskrun-maven-java17.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: maven-java17-
+  labels:
+    test: java-version
+spec:
+  taskRef:
+    name: maven
+  params:
+    - name: JAVA_VERSION
+      value: "17"
+    - name: GOALS
+      value:
+        - "--version"
+  workspaces:
+    - name: source
+      emptyDir: {}

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 ---
 images:
   minimal: registry.access.redhat.com/ubi8/ubi-minimal:8.9
-  maven: registry.access.redhat.com/ubi8/openjdk-11:latest
+  maven: registry.access.redhat.com/ubi8/openjdk-
 
 annotations:
   tekton.dev/pipelines.minVersion: "0.41.0"


### PR DESCRIPTION
Allow users to select the Java version (8, 11, 17, 21) for Maven builds via a new JAVA_VERSION string parameter. 