### PR TITLE
Add optional ENV_VARS parameter to Maven Task

### DIFF
--- a/templates/task-maven.yaml
+++ b/templates/task-maven.yaml
@@ -51,6 +51,10 @@ spec:
         The subdirectory within the repository for sources on
         which we want to execute maven goals.
       default: "."
+    - name: ENV_VARS
+      description: Array containing string of Environment Variables as "KEY=VALUE"
+      type: array
+      default: []
 
   stepTemplate:
     env:
@@ -93,10 +97,12 @@ spec:
           value: /tekton/home
       image: {{ .Values.images.maven }}$(params.JAVA_VERSION):latest
       workingDir: $(workspaces.source.path)/$(params.SUBDIRECTORY)
-      command: ["/usr/bin/mvn"]
+      command: ["/usr/bin/env"]
       args:
-        - -s
-        - maven-generate/settings.xml
+        - "$(params.ENV_VARS[*])"
+        - "/usr/bin/mvn"
+        - "-s"
+        - "maven-generate/settings.xml"
         - "$(params.GOALS[*])"
       securityContext:
         runAsNonRoot: true

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -16,6 +16,7 @@ source ./test/helper/helper.sh
         --param="URL=${E2E_MAVEN_PARAMS_URL}" \
         --param="REVISION=${E2E_MAVEN_PARAMS_REVISION}" \
         --param="VERBOSE=true" \
+        --param="ENV_VARS=MAVEN_CLEAR_REPO=false" \
         --workspace="name=server_secret,secret=${E2E_MAVEN_PARAMS_SERVER_SECRET}" \
         --workspace="name=proxy_secret,secret=${E2E_MAVEN_PARAMS_PROXY_SECRET}" \
         --workspace="name=proxy_configmap,secret=${E2E_MAVEN_PARAMS_PROXY_CONFIGMAP}" \

--- a/test/e2e/resources/pipeline-maven.yaml
+++ b/test/e2e/resources/pipeline-maven.yaml
@@ -23,6 +23,9 @@ spec:
       type: string
     - name: VERBOSE
       type: string
+    - name: ENV_VARS
+      type: array
+      default: []
 
   tasks:
     - name: git-clone
@@ -58,6 +61,8 @@ spec:
             - "validate"
         - name: SUBDIRECTORY
           value: $(context.pipelineRun.name)
+        - name: ENV_VARS
+          value: "$(params.ENV_VARS[*])"
       runAfter:
         - git-clone
       workspaces:


### PR DESCRIPTION
## Description

Adds an optional `ENV_VARS` array parameter to the Maven Task, as an array of "KEY=VALUE" strings.

This follows the same pattern used in the s2i tasks in
[task-containers](https://github.com/openshift-pipelines/task-containers/blob/main/templates/spec-s2i.tpl),
where `ENV_VARS` is declared as an array param and passed via `args`.

### Approach

The initial approach was to convert the `maven-goals` step from `command`/`args` to a `script` block
that would loop over the args, `export` each env var, and then run `mvn`. However, Tekton does not
allow array param expansion (`$(params.GOALS[*])`) inside `script` blocks — the admission webhook
rejected it with `variable type invalid`.

Instead, this PR uses `/usr/bin/env` as the step command. `env` natively accepts `KEY=VALUE` pairs
and executes a command with those variables set. This keeps both array params (`ENV_VARS` and `GOALS`)
in the `args` field where Tekton allows `[*]` expansion, and requires no shell script.

### Changes

- **`templates/task-maven.yaml`**: Added `ENV_VARS` param (type: array, default: []).
  Changed `maven-goals` step command from `/usr/bin/mvn` to `/usr/bin/env`, with
  `ENV_VARS` and the `mvn` invocation passed through `args`.
- **`test/e2e/resources/pipeline-maven.yaml`**: Added `ENV_VARS` as a pipeline param
  and wired it through to the maven task. ( used the same param as in the s2i-java)
- **`test/e2e/e2e.bats`**: Added `--param="ENV_VARS=MAVEN_CLEAR_REPO=false"` to the
  e2e test.

### Testing

- Verified `make helm-template` renders correctly
- Tested on a Kind cluster with Tekton Pipelines:
  - TaskRun with `ENV_VARS` passed — succeeded
  - TaskRun without `ENV_VARS` (default empty) — succeeded (backward compatible)